### PR TITLE
fix(issue-17): incorrect handling of neg temps on DS18B20

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The chip defines a number of attributes that alter the behavior of the  operatio
 | <span id="owDebug">`ow_debug`</span>   |  controls debug output for base one wire link layer code | `"0"`                 |
 | <span id="genDebug">`gen_debug`</span>   |  controls debug output for the chip code | `"0"`                 |
 | <span id="device_id">`device_id`</span>   |  Specifies the unique 48bit device serial number. This is a string and the value should be limited to precisely 12hex digits<br>Note the device serial's CRC is calculated during init | `"010203040506"`                 |
-| <span id="family_code">`family_code`</span>   |  Specifies the device family code. Supported values include `0x10`, `0x22`, `0x28` | `"0x10"`                 |
+| <span id="family_code">`family_code`</span>   |  Specifies the device family code. Supported values include `0x10`, `0x22`, `0x28`<br>Note that the values have to be specified as decimal and not hex, so `0x28 -> 40`, `0x10 -> 16` etc. | `"0x10"`                 |
 | <span id="temperature">`temperature`</span>   |  Specifies the reported temperature. Float attribute should be in the range -55 .. 125 | `"0"` |
 | <span id="min_temp">`min_temp`</span>   |  Specifies the minimum temperature in the range. Float attribute should be in the range -55 .. 125 | `"0"` |
 | <span id="max_temp">`max_temp`</span>   |  Specifies the maximum temperature in the range. Float attribute should be in the range -55 .. 125 | `"0"` |

--- a/diagram.json
+++ b/diagram.json
@@ -4,9 +4,9 @@
   "editor": "wokwi",
   "parts": [
     { "type": "wokwi-arduino-uno", "id": "mega", "top": 0, "left": 0, "attrs": {} },
-    { "type": "chip-ds18b20", "id": "chip", "top": -104, "left": 181.34, "attrs": { "gen_debug": "0", "device_id": "010203040506", "ow_debug": "0", "temperature":"25.9375", "family_code": "16", "min_temp": "10", "max_temp": "20", "temp_wave_form": "triangle", "temp_wave_freq": "0.0156"} },
+    { "type": "chip-ds18b20", "id": "chip", "top": -104, "left": 181.34, "attrs": { "gen_debug": "1", "device_id": "010203040506", "ow_debug": "0", "temperature":"25.9375", "family_code": "40", "min_temp": "-55", "max_temp": "125", "temp_wave_form": "fixed", "temp_wave_freq": "0.0156"} },
     { "type": "wokwi-led", "id": "led", "top": -104, "left": 181.34, "attrs": { } },
-    { "type": "wokwi-logic-analyzer", "id": "logic1", "top": -248.9, "left": 25.41, "attrs": {"triggerMode":"level", "triggerPin":"D7", "triggerLevel":"high"} }
+    { "type": "wokwi-logic-analyzer", "id": "logic1", "top": -248.9, "left": 25.41, "attrs": {"triggerMode":"level", "triggerPin":"D7", "triggerLevel":"low"} }
   ],
   "connections": [
     [ "chip:VCC", "mega:5V", "red", [ "h116.15", "v336.49", "h-241.58" ] ],


### PR DESCRIPTION
closes #17 

Thanks to @dpticar for identifying the issue and following up.

Code for storing negative values in scratchpad was overly complicated and a carry over from other code.

